### PR TITLE
Update README to explicitly install dotnet 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - Install Chocolaty from https://chocolatey.org/install
 - Launch an Administrator Command Prompt and run the following:
 ```
-choco install dotnet netfx-4.8 python3 wixtoolset
+choco install dotnet-6.0-sdk netfx-4.8 python3 wixtoolset
 ```
 - Launch a normal Command Prompt and run the following:
 ```


### PR DESCRIPTION
Doing `choco install dotnet` will install the dotnet 7 SDK, and this won't build for me without having the dotnet 6 SDK.

This PR updates the README to specifically install the dotnet 6 SDK.

(Although, I haven't tried this from scratch! I did `choco install dotnet` had it not work, then did `choco install dotnet-6.0-sdk` so it's possible we still need the `dotnet` package as well? Someone will have to try this on a fresh machine to see for sure.)